### PR TITLE
fix post:new command so that the task outpout correct publish date

### DIFF
--- a/_task/node-trello-contents.js
+++ b/_task/node-trello-contents.js
@@ -39,6 +39,8 @@ const getNextWednesday = () => {
 
   const date = new Date();
   date.setDate(date.getDate() + ((3 + 7 - date.getDay()) % 7));
+  // 東京の時間に合わせる
+  date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
   return yyyymmddify(date);
 };
 


### PR DESCRIPTION
次の水曜日を取得する際、基準とする時間が、日本時間になってない問題により、水曜日にならない場合がある問題を修正